### PR TITLE
Display toc from 1366 pixels

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -235,7 +235,7 @@ div.canvas canvas {
   padding-left: 0em;
   padding-right: 2em;
 }
-@media only screen and (max-width: 1500px) {
+@media only screen and (max-width: 1365px) {
   .toc {
     display: none;
   }


### PR DESCRIPTION
Hi,
I love reading your long posts and find the table of contents very convenient, however, it currently only displays on screens over 1500 pixels, which excludes most laptop screens. This PR lowers the limit to 1366 pixels to include more screens.